### PR TITLE
Fix: Replace unsupported repeated yaml anchors w/ merge

### DIFF
--- a/docker-compose-ref.yml
+++ b/docker-compose-ref.yml
@@ -27,8 +27,7 @@ services:
   db:
     image: mysql:8.0.22
     container_name: idp-mysql
-    <<: *service-network-ref
-    <<: *service-setup-ref
+    <<: [*service-network-ref, *service-setup-ref]
     environment:
       MYSQL_ROOT_USER: root
       MYSQL_ROOT_PASSWORD: idp
@@ -49,8 +48,7 @@ services:
     image: eu.gcr.io/gematik-all-infra-prod/idp/idp-server:${appVersion}
     user: 10000:10000
     container_name: idp-server
-    <<: *service-network-ref
-    <<: *service-setup-ref
+    <<: [*service-network-ref, *service-setup-ref]
     environment:
       SPRING_DATASOURCE_URL: "jdbc:mysql://db:3306/IDP"
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: "com.mysql.cj.jdbc.Driver"


### PR DESCRIPTION
The use of duplicate YAML merge keys `(<<)` is now rejected from latest docker-compose spec.

It fails with the following syntax error due to go/yaml/v3 update:

```sh
$ docker-compose --project-name myidp -f docker-compose-ref.yml up -d
parsing ./docker-compose-ref.yml: yaml: unmarshal errors:
  line 32: mapping key "<<" already defined at line 31
  line 55: mapping key "<<" already defined at line 54
```

> goyaml/v3 does not support repeated anchors (due to internal storage using << as key during parsing) but allows use of multi-values in anchors.

References:
- docker/compose#10411 (comment)
- https://github.com/docker/docs/pull/17107
- https://yaml.org/type/merge.html
