### PR TITLE
Add dynamic OpenAPI specification generation w/ SpringDoc

### DIFF
--- a/idp-server/pom.xml
+++ b/idp-server/pom.xml
@@ -55,6 +55,13 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <version>2.1.0</version>
+   </dependency>
+
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>

--- a/idp-server/src/main/resources/application.yml
+++ b/idp-server/src/main/resources/application.yml
@@ -237,7 +237,7 @@ management:
     web:
       exposure:
         include: "health"
-    enabled-by-default: false
+    enabled-by-default: true
   endpoint:
     health:
       enabled: true
@@ -260,3 +260,10 @@ spring:
       enabled: true
       settings:
         web-allow-others: true
+springdoc:
+  show-actuator: true
+  swagger-ui:
+    enabled: true
+    path: /swagger-ui.html
+  api-docs:
+    enabled: true


### PR DESCRIPTION
This commit adds the SpringDoc OpenAPI Starter WebMVC UI dependency to the pom.xml file, and enables Swagger UI in the application.yml file. 

This allows for API documentation to be generated and viewed through a user-friendly interface.

Once the idp-server is running (e.g. on 127.0.0.1:8080), the Swagger UI will be available on `/swagger-ui/index.html` as well as the corresponding generated API specification on `/v3/api-docs/springdocDefault`

**Important notes regarding the usage in productive environments:**

It is recommended to NOT enable the Swagger UI / OpenAPI explorer interface when running the server publicly exposed.    

Yet being able to explore the API interfaces provides a useful addition for developing applications and products against the identity provider.  

Please consider publishing a official OpenAPI specification!
