### PR TITLE
Bump mysql to 8.0.29 to provide full development compatibility on arm64

### DIFF
--- a/docker-compose-ref.yml
+++ b/docker-compose-ref.yml
@@ -25,7 +25,7 @@ x-service-network: &service-network-ref
 services:
   # Database
   db:
-    image: mysql:8.0.22
+    image: mysql:8.0.29
     container_name: idp-mysql
     <<: [*service-network-ref, *service-setup-ref]
     environment:


### PR DESCRIPTION
This commit updates the the mysql docker image tag to 8.0.29.

Updating mysql to 8.0.29 and its corresponding docker tag (`mysql:8.0.29`) improves the support for developing and running on arm64 architectures and Apple Silicon machines.

Related: https://github.com/gematik/ref-idp-server/issues/9

## Explanation:
 
Currently, the used docker image for mysql (`mysql:8.0.22`) is published only for architecture `linux/amd64` and has to be used with Apple's Rosetta compatibility layer enabled.

`mysql:8.0.29` is the first **stable** version also targeting arm64.

### References:

- Docker Hub entry for 8.0.22: https://hub.docker.com/layers/library/mysql/8.0.22/images/sha256-7d83f4d89c92d7e72b366cc9d0f5c19b12cba934c5e135d21d81b2b84651df69?context=explore
- Docker Hub entry for 8.0.29: https://hub.docker.com/layers/library/mysql/8.0.29/images/sha256-12cf01a51f803d0ad49ee0dbbb3025a6eef3341e24757c2ed8150b6654c3fb07?context=explore

### Disclaimer:

A quick review of mysql's version changelog shows no compatibility issues. All unit tests finished without any issues.

### Workaround:

Add the `platform` property to the docker service to trigger Rosetta 2 on Apple Silicon:

```yaml
services:
  # Database
  db:
    image: mysql:8.0.22
    container_name: idp-mysql
    <<: [*service-network-ref, *service-setup-ref]
    environment:
      MYSQL_ROOT_USER: root
      MYSQL_ROOT_PASSWORD: idp
      MYSQL_DATABASE: IDP
      <<: *environment-timezone-ref
    ports:
      - "8572:3306"
    volumes:
      - idp-data-db:/var/lib/mysql
    healthcheck:
      test: "/usr/bin/mysql --user=root --password=idp --execute \"SHOW DATABASES;\""
      interval: 20s
      timeout: 20s
      retries: 10
    # in case of development on Apple Silicon to trigger Rosetta 2
    platform: linux/amd64
```