### PR TITLE
Issue 43 - Fix environment variable IDP_SERVER_URL in docker-compose-ref.yml

### DIFF
--- a/docker-compose-ref.yml
+++ b/docker-compose-ref.yml
@@ -57,7 +57,7 @@ services:
       SPRING_DATASOURCE_INITIALIZATION_MODE: always
       SPRING_JPA_DATABASE_PLATFORM: "org.hibernate.dialect.MySQLDialect"
       SPRING_H2_CONSOLE_ENABLED: "false"
-      IDP_SERVERURL: ""
+      IDP_SERVER_URL: "${IDP_SERVER_URL}:-http://localhost:8571"
       idp.loglevel: ${serverLoglevel:-info}
       MANAGEMENT_PORT: 8180 # Spring Actuator Port
       <<: *environment-timezone-ref


### PR DESCRIPTION
[Issue 43](https://github.com/gematik/ref-idp-server/issues/43)

___
According to the README:

The idp-server determines the URL in the following priority order if it exists:

1. JVM argument: --idp.serverUrl=https://myserverurlasjvmargument.de/
2. Environment variable: IDP_SERVER_URL=myServerUrlFromEnv:8080
3. Spring Boot configuration (application.yml):
Issue 1:
The environment variable IDP_SERVER_URL is never set when using the docker-compose-ref.yml file because it is misspelled as IDP_SERVERURL in the environment declaration (missing the second underscore between IDP_SERVER and URL).

Issue 2:
The http://localhost:8571/discoveryDocument endpoint returns a JWT token that still refers to http://localhost:8080/ endpoints, which can cause misconfigurations when deploying the server in different environments.

Solution:
To fix both issues, I made the following change in docker-compose-ref.yml:

Updated the environment variable from IDP_SERVERURL to IDP_SERVER_URL to correctly set the URL.
Adjusted the default value of IDP_SERVER_URL to ensure it correctly points to the desired endpoint.
The fix was made by editing a single line (60) in the docker-compose-ref.yml file:

From:
IDP_SERVERURL: ""
To:
IDP_SERVER_URL: "${IDP_SERVER_URL:-http://localhost:8571}"
This change ensures that the IDP_SERVER_URL environment variable is correctly set for the ports mapped in the docker compose and can be still overridden by IDP_SERVER_URL values set by--env-file or export commands


